### PR TITLE
fix: remove staysonbottomhint

### DIFF
--- a/src/contentswindow.cpp
+++ b/src/contentswindow.cpp
@@ -58,7 +58,6 @@ ContentsWindow::ContentsWindow()
     setTitle(i18n("Wayland to X Recording bridge"));
 
     setOpacity(0);
-    setFlag(Qt::WindowStaysOnBottomHint);
     setFlag(Qt::WindowDoesNotAcceptFocus);
     setFlag(Qt::WindowTransparentForInput);
     KWindowSystem::setState(winId(), NET::SkipTaskbar | NET::SkipPager);


### PR DESCRIPTION
Removing the Qt::WindowStaysOnBottomHint everything start to work to me, Fedora 38 -> Gnome 44

https://bugs.kde.org/show_bug.cgi?id=471140