### PR TITLE
Fixed missing find_package for Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 
 
 find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Quick DBus Widgets)
+if(QT_MAJOR_VERSION STREQUAL "6")
+    find_package(Qt6 COMPONENTS GuiPrivate REQUIRED)
+endif()
 if(QT_MAJOR_VERSION STREQUAL "5")
     find_package(Qt5X11Extras ${QT_MIN_VERSION} REQUIRED)
 endif()


### PR DESCRIPTION
### Problem
Building xwaylandvideobridge with Qt6 fails during the CMake configuration phase with the following error:
``` shell
CMake Error at src/CMakeLists.txt:41 (target_link_libraries):
  Target "xwaylandvideobridge" links to:
    Qt6::GuiPrivate
  but the target was not found.  Possible reasons include:
    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

### Root Cause
In src/CMakeLists.txt, the Qt6 build path links against Qt6::GuiPrivate:
``` cmake
if (QT_MAJOR_VERSION STREQUAL "6")
    target_link_libraries(xwaylandvideobridge Qt6::GuiPrivate KF6::StatusNotifierItem)
endif()
```
However, the main CMakeLists.txt never calls find_package() for the GuiPrivate component. In CMake, imported targets like Qt6::GuiPrivate are only available after their corresponding find_package() call. Without it, CMake cannot locate the target and the build fails.

### The Fix
Add the missing find_package() call in CMakeLists.txt:
```
if(QT_MAJOR_VERSION STREQUAL "6")
    find_package(Qt6 COMPONENTS GuiPrivate REQUIRED)
endif()
```
This is placed alongside the existing Qt6/Qt5 conditional blocks for consistency.

### Why This Works
- find_package(Qt6 COMPONENTS GuiPrivate REQUIRED) instructs CMake to locate Qt6's GuiPrivate module and create the Qt6::GuiPrivate imported target
- The GuiPrivate component provides access to Qt's private API headers, which are needed by this project
- On most distributions, Qt6::GuiPrivate is provided by the same package as qt6-base (e.g., the CMake config files are in /usr/lib/cmake/Qt6GuiPrivate/)
- The REQUIRED keyword ensures the build fails early with a clear error if the component isn't available, rather than failing later at link time
- This fix is consistent with how Qt5X11Extras is already handled for Qt5 builds
Testing
Confirmed that the build succeeds on Arch Linux with Qt 6.10.1 after applying this patch.